### PR TITLE
 chore(infra): configure S3 remote backend for Terraform state 

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,15 @@ Use the provided example script to test your live endpoint.
     ```
     You should see a success message and receive an email at your verified recipient address! 🎉
 
-### 📈 Next Steps & Tech Debt
+### 🗺️ Architectural Roadmap & Future Vision
 
-This project is a solid foundation. Here are some documented next steps:
-* **Terraform S3 Backend:** Configure a remote backend for the Terraform state to enable team collaboration.
-* **CI/CD Pipeline:** Create a GitHub Actions workflow to automate testing and deployment.
-* **Optimize with a Bundler:** Refactor the build process to use `esbuild` for faster cold starts and a smaller package size.
+With the foundational CI/CD pipeline, remote state management, and build optimizations in place, this project serves as a robust and stable blueprint for serverless applications.
+
+The next planned architectural evolution is to enhance the system's resilience and scalability, transforming it into a truly event-driven service.
+
+* **Evolve to an Asynchronous, Event-Driven Architecture**
+    * **The Vision:** Introduce an **Amazon SQS queue** to decouple the initial API request from the actual notification sending process. The API Lambda's only job would be to validate and enqueue the request, providing an instant response to the client. A separate processor Lambda would then consume messages from this queue asynchronously.
+    * **Key Benefits:**
+        * **✨ Instant API Responses:** Clients no longer wait for the email to be sent.
+        * **🛡️ Greater Resilience & Reliability:** Protects against failures and downtime of the email service (SES). With retries and a Dead-Letter Queue (DLQ), no notification is ever lost.
+        * **🌊 Massive Scalability:** The system can gracefully handle huge traffic spikes by buffering requests in the queue.

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,13 @@
+# terraform/backend.tf
+
+terraform {
+  backend "s3" {
+    bucket         = "fcapellatw-notification-service-tfstate"
+    key            = "global/terraform.tfstate"
+    region         = "us-east-1"
+
+    # O nome da tabela DynamoDB para o lock
+    dynamodb_table = "terraform-state-locks"
+    encrypt        = true
+  }
+}


### PR DESCRIPTION
This commit resolves a critical technical debt by moving the Terraform state from local files to a secure, centralized remote backend on AWS. This is a foundational step for enabling secure collaboration and a reliable CI/CD pipeline.

The local state management was insecure (risk of committing secrets) and made collaboration impossible, as each developer and the CI/CD pipeline had their own separate "map" of the infrastructure.

Key changes implemented:
- **`backend.tf`:** A new configuration file was added to instruct Terraform to use an S3 bucket for state storage and a DynamoDB table for state locking.
- **IAM Policy Update:** The `NotificationServiceDeployPolicy`, used by the GitHub Actions OIDC Role, was updated to include the necessary permissions for S3 (`s3:GetObject`, `s3:PutObject`) and DynamoDB (`dynamodb:GetItem`, `dynamodb:PutItem`, `dynamodb:DeleteItem`).
- **`.gitignore`:** The `.gitignore` file was updated to explicitly ignore local Terraform state files (`.tfstate`, `.tfstate.backup`), ensuring they are never committed to the repository.
- ** `README.md`: ** Updated roadmap to reflect current status.

With this change, both local development and the CI/CD pipeline now share a single, consistent, and securely managed source of truth for the infrastructure state.